### PR TITLE
Enhance WiX project files to better handle MSBuild15

### DIFF
--- a/src/Templates/v3/Projects/CustomActionCS/CustomAction.csproj
+++ b/src/Templates/v3/Projects/CustomActionCS/CustomAction.csproj
@@ -12,7 +12,6 @@
 		<AssemblyName>$safeprojectname$</AssemblyName>
 		<TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
-		<WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.CA.targets</WixCATargetsPath>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -25,7 +24,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
 		<DebugType>pdbonly</DebugType>
- 		<Optimize>true</Optimize>
+		<Optimize>true</Optimize>
 		<OutputPath>bin\Release\</OutputPath>
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
@@ -39,7 +38,7 @@
 		$endif$
 		$if$ ($targetframeworkversion$ >= 4.0)
 		<Reference Include="Microsoft.CSharp" />
- 		$endif$
+		$endif$
 		<Reference Include="System.Xml"/>
 		<Reference Include="Microsoft.Deployment.WindowsInstaller">
 			<Private>True</Private>
@@ -51,8 +50,9 @@
 		<Content Include="CustomAction.config" />
 	</ItemGroup>
 	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-	<Import Project="$(WixCATargetsPath)" Condition=" Exists('$(WixCATargetsPath)') " />
-	<Target Name="EnsureWixToolsetInstalled" Condition=" !Exists('$(WixCATargetsPath)') ">
-		<Error Text="The WiX Toolset build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+	<Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' " />
+	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets" Condition=" '$(WixCATargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets') " />
+	<Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixCATargetsImported)' != 'true' ">
+		<Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
 	</Target>
 </Project>

--- a/src/Templates/v3/Projects/CustomActionVB/CustomAction.vbproj
+++ b/src/Templates/v3/Projects/CustomActionVB/CustomAction.vbproj
@@ -12,7 +12,6 @@
 		<TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 		<MyType>Windows</MyType>
-		<WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.CA.targets</WixCATargetsPath>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -59,8 +58,9 @@ $endif$
 		<Content Include="CustomAction.config" />
 	</ItemGroup>
 	<Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
-	<Import Project="$(WixCATargetsPath)" Condition=" Exists('$(WixCATargetsPath)') " />
-	<Target Name="EnsureWixToolsetInstalled" Condition=" !Exists('$(WixCATargetsPath)') ">
-		<Error Text="The WiX Toolset build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+	<Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' " />
+	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets" Condition=" '$(WixCATargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets') " />
+	<Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixCATargetsImported)' != 'true' ">
+		<Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
 	</Target>
- </Project>
+</Project>

--- a/src/Templates/v3/Projects/WixBundleProject/BundleProject.wixproj
+++ b/src/Templates/v3/Projects/WixBundleProject/BundleProject.wixproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -7,8 +8,6 @@
 		<SchemaVersion>2.0</SchemaVersion>
 		<OutputName>$safeprojectname$</OutputName>
 		<OutputType>Bundle</OutputType>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix2010.targets</WixTargetsPath>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix2010.targets</WixTargetsPath>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<OutputPath>bin\$(Configuration)\</OutputPath>
@@ -28,8 +27,9 @@
 			<Name>WixBalExtension</Name>
 		</WixExtension>
 	</ItemGroup>
-	<Import Project="$(WixTargetsPath)" Condition=" Exists('$(WixTargetsPath)') " />
-	<Target Name="EnsureWixToolsetInstalled" Condition=" !Exists('$(WixTargetsPath)') ">
+	<Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+	<Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
 		<Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
 	</Target>
 	<!--

--- a/src/Templates/v3/Projects/WixLibrary/setuplibrary.wixproj
+++ b/src/Templates/v3/Projects/WixLibrary/setuplibrary.wixproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -7,8 +8,6 @@
 		<SchemaVersion>2.0</SchemaVersion>
 		<OutputName>$safeprojectname$</OutputName>
 		<OutputType>Library</OutputType>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<OutputPath>bin\$(Configuration)\</OutputPath>
@@ -22,8 +21,9 @@
 	<ItemGroup>
 		<Compile Include="Library.wxs" />
 	</ItemGroup>
-	<Import Project="$(WixTargetsPath)" Condition=" Exists('$(WixTargetsPath)') " />
-	<Target Name="EnsureWixToolsetInstalled" Condition=" !Exists('$(WixTargetsPath)') ">
+	<Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+	<Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
 		<Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
 	</Target>
 	<!--

--- a/src/Templates/v3/Projects/WixMergeModule/MergeModule.wixproj
+++ b/src/Templates/v3/Projects/WixMergeModule/MergeModule.wixproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -7,8 +8,6 @@
 		<SchemaVersion>2.0</SchemaVersion>
 		<OutputName>$safeprojectname$</OutputName>
 		<OutputType>Module</OutputType>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<OutputPath>bin\$(Configuration)\</OutputPath>
@@ -22,8 +21,9 @@
 	<ItemGroup>
 		<Compile Include="MergeModule.wxs" />
 	</ItemGroup>
-	<Import Project="$(WixTargetsPath)" Condition=" Exists('$(WixTargetsPath)') " />
-	<Target Name="EnsureWixToolsetInstalled" Condition=" !Exists('$(WixTargetsPath)') ">
+	<Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+	<Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
 		<Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
 	</Target>
 	<!--

--- a/src/Templates/v3/Projects/WixProject/SetupProject.wixproj
+++ b/src/Templates/v3/Projects/WixProject/SetupProject.wixproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -7,8 +8,6 @@
 		<SchemaVersion>2.0</SchemaVersion>
 		<OutputName>$safeprojectname$</OutputName>
 		<OutputType>Package</OutputType>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
-		<WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<OutputPath>bin\$(Configuration)\</OutputPath>
@@ -22,8 +21,9 @@
 	<ItemGroup>
 		<Compile Include="Product.wxs" />
 	</ItemGroup>
-	<Import Project="$(WixTargetsPath)" Condition=" Exists('$(WixTargetsPath)') " />
-	<Target Name="EnsureWixToolsetInstalled" Condition=" !Exists('$(WixTargetsPath)') ">
+	<Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+	<Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
 		<Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
 	</Target>
 	<!--

--- a/tools/WixBuild.csproj.props
+++ b/tools/WixBuild.csproj.props
@@ -20,7 +20,7 @@
     <WarningLevel>4</WarningLevel>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)'=='' ">v4.0</TargetFrameworkVersion>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <NoWarn Condition=" '$(CopyBuildOutputToOutputDirectory)'=='false' ">$(NoWarn);2008</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
MSBuild15 only evaluates all MSBuildExtensionPaths when the property is
directly passed to MSBuild for evaluation.  For more details see:
https://github.com/Microsoft/msbuild/issues/1832

Addresses wixtoolset/issues#5525

Dependent upon https://github.com/wixtoolset/wix3/pull/437