### PR TITLE
Use default colors in VS2022.

### DIFF
--- a/src/votive.shared/PropertyPages/WixPropertyPagePanel.cs
+++ b/src/votive.shared/PropertyPages/WixPropertyPagePanel.cs
@@ -43,12 +43,7 @@ namespace WixToolset.VisualStudioExtension.PropertyPages
             this.InitializeComponent();
 
             this.Font = WixHelperMethods.GetDialogFont();
-#if Dev17
-             // VS2022 doesn't use theming on property pages
-            this.BackColor = SystemColors.Control;
-#else
             this.BackColor = WixHelperMethods.GetVsColor(WixHelperMethods.Vs2010Color.VSCOLOR_BUTTONFACE);
-#endif
             this.ForeColor = WixHelperMethods.GetVsColor(WixHelperMethods.Vs2010Color.VSCOLOR_BUTTONTEXT);
         }
 

--- a/src/votive.shared/WixHelperMethods.cs
+++ b/src/votive.shared/WixHelperMethods.cs
@@ -678,8 +678,7 @@ namespace WixToolset.VisualStudioExtension
         internal static void SetSingleControlColors(Control control)
         {
             control.ForeColor = GetVsColor(Vs2010Color.VSCOLOR_BUTTONTEXT);
-            if (control is TextBox || control is ListBox || control is ListView || control is ComboBox ||
-                control is WixBuildEventTextBox)
+            if (control is TextBox || control is ListBox || control is ListView || control is ComboBox)
             {
                 control.BackColor = GetVsColor(Vs2010Color.VSCOLOR_WINDOW);
             }
@@ -692,6 +691,7 @@ namespace WixToolset.VisualStudioExtension
         /// <returns>The color itself</returns>
         internal static Color GetVsColor(Vs2010Color visualStudioColor)
         {
+#if !Dev17 // VS2022 doesn't support theming for legacy property pages
             uint win32Color = 0;
             IVsUIShell2 vsuiShell2 = WixPackage.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell2;
             if (vsuiShell2 != null && vsuiShell2.GetVSSysColorEx((Int32)visualStudioColor, out win32Color) == VSConstants.S_OK)
@@ -699,13 +699,14 @@ namespace WixToolset.VisualStudioExtension
                 Color color = ColorTranslator.FromWin32((int)win32Color);
                 return color;
             }
+#endif
 
             // We need to fall back to some reasonable colors when we're not running in VS
             // to keep the forms/property pages editable in the designers
             switch (visualStudioColor)
             {
                 case Vs2010Color.VSCOLOR_BUTTONFACE:
-                    return SystemColors.ButtonFace;
+                    return SystemColors.Control;
 
                 case Vs2010Color.VSCOLOR_BUTTONTEXT:
                     return SystemColors.ControlText;


### PR DESCRIPTION
Current implementation of the plugin GUI uses the legacy approach for property page implementation, which doesn't allow for
proper theming support. Existing property pages for .NET 4.8 projects and below exhibit the same behaviour.

Fixes wixtoolset/issues#6643.