### PR TITLE
Don't attempt to support IVsDebuggableProjectCfg.

### DIFF
--- a/src/votive.shared/ProjectBase/ProjectConfig.cs
+++ b/src/votive.shared/ProjectBase/ProjectConfig.cs
@@ -900,9 +900,7 @@ namespace Microsoft.VisualStudio.Package
 			ppCfg = IntPtr.Zero;
 
 			// See if this is an interface we support
-			if (iidCfg == typeof(IVsDebuggableProjectCfg).GUID)
-				ppCfg = Marshal.GetComInterfaceForObject(this, typeof(IVsDebuggableProjectCfg));
-			else if (iidCfg == typeof(IVsBuildableProjectCfg).GUID)
+			if (iidCfg == typeof(IVsBuildableProjectCfg).GUID)
 			{
 				IVsBuildableProjectCfg buildableConfig;
 				this.get_BuildableProjectCfg(out buildableConfig);


### PR DESCRIPTION
This results in an InvalidCastException and seems to have done so for a long time.  Prior to VS2022 Preview 4, VS would swallow this exception and there seemed to be no observable detrimental effects.  However, starting with VS2022 Preview 4, VS changed their handling of these calls and no longer swallow the exception.  The exceptions bubbles up the stack and prevents the .wixproj from opening.

Fixes wixtoolset/issues#6753.